### PR TITLE
NapResponse Constructor Error when using a BaseUrl

### DIFF
--- a/src/Nap/NapRequest.cs
+++ b/src/Nap/NapRequest.cs
@@ -359,7 +359,7 @@ namespace Nap
         /// Creates the URL from an (optional) <see cref="INapConfig.BaseUrl"/>, URL and query parameters.
         /// </summary>
         /// <returns>The fully formed URL.</returns>
-        private string CreateUrl()
+        internal string CreateUrl()
         {
             var urlTemp = _url;
             if (!_url.StartsWith("http", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(_config.BaseUrl))

--- a/src/Nap/NapResponse.cs
+++ b/src/Nap/NapResponse.cs
@@ -67,14 +67,14 @@ namespace Nap
         internal NapResponse(NapRequest request, HttpResponseMessage response, string body)
         {
             Request = request;
-            Url = new Uri(request.Url);
+            Url = new Uri(request.CreateUrl());
             StatusCode = response.StatusCode;
             Headers = new ReadOnlyCollection<KeyValuePair<string, string>>(response.Headers
                                                                                    .Union(response.Content.Headers)
                                                                                    .SelectMany(h => h.Value.Select(v => new KeyValuePair<string, string>(h.Key, v)))
                                                                                    .ToList());
             Cookies = new ReadOnlyCollection<NapCookie>(Headers.Where(h => h.Key.Equals("set-cookie", StringComparison.OrdinalIgnoreCase))
-                                                               .Select(h => new NapCookie(new Uri(request.Url), h.Value))
+                                                               .Select(h => new NapCookie(new Uri(request.CreateUrl()), h.Value))
                                                                .ToList());
             Body = body;
             ContentHeaders = response.Content.Headers;


### PR DESCRIPTION
NapResponse throws an error in the constructor when a BaseUrl is in use on the passed in NapRequest. The 'new Uri' creating fails.

This pull request uses the NapRequest CreateUrl method. It was made internal so it can make that call.